### PR TITLE
fix: Use Idtyp for individ list

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -18,7 +18,6 @@ paths:
           description: Handläggarens id
           schema:
             type: string
-            format: uuid
       responses:
         '200':
           description: Ny uppgift hämtad OK
@@ -40,7 +39,6 @@ paths:
           description: Handläggarens id
           schema:
             type: string
-            format: uuid
       responses:
         '200':
           description: Uppgifter hämtade OK
@@ -88,7 +86,6 @@ components:
           description: DateTime av när uppgiften skapades i ISO 8601 format
         handlaggar_id:
           type: string
-          format: uuid
           description: Unikt ID för den tilldelade handläggaren
         planerad_till:
           type: string
@@ -109,10 +106,9 @@ components:
             - Avslutad
         individer:
           type: array
-          description: Lista av individ-ID (UUID)
+          description: Lista av individ-ID
           items:
-            type: string
-            format: uuid
+            $ref: '#/components/schemas/Idtyp'
         regel:
           type: string
           description: Namn på regeln
@@ -137,3 +133,19 @@ components:
           handlaggning_id: "5f3e26ca-c7f7-4711-b2ee-c09b38fa6f1c"
           status: "Tilldelad"
           skapad: "2025-03-25T00:00:00Z"
+
+    Idtyp:
+      type: object
+      properties:
+        typId:
+          type: string
+          description: Unikt ID som identifierar vilken typ av värde som anges
+        varde:
+          type: string
+          description: ID-värde som identifieras av typ
+      required:
+        - typId
+        - varde
+      example:
+        typId: "4c34906c-03d9-425f-9a1a-062ef6eb88c7"
+        varde: "19901010-1234"


### PR DESCRIPTION
This commit replaces the individ uuid list with a list of Idtyp in order to match values provided by rules. It also lifts the restriction that handlaggare_id must be uuid in order to match asyncapi changes.