### PR TITLE
Add team task overview and reassignment endpoints (FKPOC-833)

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -85,7 +85,7 @@ paths:
         '403':
           description: Handläggaren tillhör inte ett känt team
 
-  /uppgifter/{uppgift_id}/handlaggare/{id_typ}/{id_varde}:
+  /uppgifter/{uppgift_id}/handlaggare:
     parameters:
       - name: uppgift_id
         in: path
@@ -94,25 +94,17 @@ paths:
         schema:
           type: string
           format: uuid
-      - name: id_typ
-        in: path
-        required: true
-        description: Typ av identifiering av den handläggare som ska tilldelas uppgiften
-        schema:
-          type: string
-          example: "kortnummer"
-      - name: id_varde
-        in: path
-        required: true
-        description: Unik identifiering av den handläggare som ska tilldelas uppgiften
-        schema:
-          type: string
-          example: "123456789"
     post:
       tags: [OperativtUppgiftslagerController]
       operationId: postUppgiftHandlaggare
       summary: Tilldela om en uppgift till en annan handläggare
       description: Tilldelar uppgiften till den angivna handläggaren. Kräver att uppgiftens nuvarande tilldelade handläggare tillhör samma team.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Idtyp'
       responses:
         '200':
           description: Uppgiften omtilldelad OK

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.3
 info:
   title: Operativt uppgiftslager API
   version: 1.0.0
-  description: API för handläggare att hämta ny uppgift och lista sina tilldelade operativa uppgifter.
+  description: API för handläggare att hämta ny uppgift, lista tilldelade operativa uppgifter, se teamets uppgifter samt tilldela om en uppgift till sig själv från en kollega i samma team.
 
 security:
   - bearerAuth: []
@@ -23,28 +23,11 @@ paths:
                 $ref: '#/components/schemas/PostUppgifterHandlaggareResponse'
         '400':
           description: Bad request
-
-  /uppgifter/handlaggare/{id_typ}/{id_varde}:
-    parameters:
-      - name: id_typ
-        in: path
-        required: true
-        description: Typ av identifiering av handläggare
-        schema:
-          type: string
-          example: "kortnummer"
-      - name: id_varde
-        in: path
-        required: true
-        description: Unik identifiering av handläggare
-        schema:
-          type: string
-          example: "123456789"
     get:
       tags: [OperativtUppgiftslagerController]
       operationId: getUppgifterHandlaggare
-      summary: Hämta operativa uppgifter som tilldelats handläggare
-      description: Hämta operativa uppgifter som tilldelats handläggare
+      summary: Hämta operativa uppgifter tilldelade till den anropande handläggaren
+      description: Returnerar operativa uppgifter tilldelade till den anropande handläggaren. Handläggarens identitet hämtas från bearer-token.
       responses:
         '200':
           description: Uppgifter hämtade OK
@@ -52,10 +35,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/GetUppgifterHandlaggareResponse'
-        '400':
-          description: Bad request (t.ex. felaktigt handlaggar_id)
-        '403':
-          description: Handläggaren tillhör inte teamet
 
   /uppgifter/team:
     get:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -49,7 +49,84 @@ paths:
                 $ref: '#/components/schemas/GetUppgifterHandlaggareResponse'
         '400':
           description: Bad request (t.ex. felaktigt handlaggar_id)
-  
+        '403':
+          description: Handläggaren tillhör inte teamet
+
+  /uppgifter/team/{id_typ}/{id_varde}:
+    parameters:
+      - name: id_typ
+        in: path
+        required: true
+        description: Typ av identifiering av handläggare
+        schema:
+          type: string
+          example: "kortnummer"
+      - name: id_varde
+        in: path
+        required: true
+        description: Unik identifiering av handläggare
+        schema:
+          type: string
+          example: "123456789"
+    get:
+      tags: [OperativtUppgiftslagerController]
+      operationId: getUppgifterTeam
+      summary: Hämta operativa uppgifter tilldelade till handläggarens team
+      description: Returnerar alla operativa uppgifter tilldelade till någon av handläggarens team-medlemmar
+      responses:
+        '200':
+          description: Uppgifter hämtade OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetUppgifterHandlaggareResponse'
+        '400':
+          description: Bad request (t.ex. felaktigt id_varde)
+        '403':
+          description: Handläggaren tillhör inte ett känt team
+
+  /uppgifter/{uppgift_id}/handlaggare/{id_typ}/{id_varde}:
+    parameters:
+      - name: uppgift_id
+        in: path
+        required: true
+        description: ID för den uppgift som ska tilldelas om
+        schema:
+          type: string
+          format: uuid
+      - name: id_typ
+        in: path
+        required: true
+        description: Typ av identifiering av den handläggare som ska tilldelas uppgiften
+        schema:
+          type: string
+          example: "kortnummer"
+      - name: id_varde
+        in: path
+        required: true
+        description: Unik identifiering av den handläggare som ska tilldelas uppgiften
+        schema:
+          type: string
+          example: "123456789"
+    post:
+      tags: [OperativtUppgiftslagerController]
+      operationId: postUppgiftHandlaggare
+      summary: Tilldela om en uppgift till en annan handläggare
+      description: Tilldelar uppgiften till den angivna handläggaren. Kräver att uppgiftens nuvarande tilldelade handläggare tillhör samma team.
+      responses:
+        '200':
+          description: Uppgiften omtilldelad OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PostUppgiftHandlaggareResponse'
+        '400':
+          description: Bad request (t.ex. felaktigt uppgift_id eller handlaggar_id)
+        '403':
+          description: Handläggaren tillhör inte teamet
+        '404':
+          description: Uppgiften hittades inte
+
 components:
   schemas:
     PostUppgifterHandlaggareResponse:
@@ -58,6 +135,14 @@ components:
         operativ_uppgift:
           $ref: '#/components/schemas/OperativUppgift'
           nullable: true
+
+    PostUppgiftHandlaggareResponse:
+      type: object
+      required:
+        - operativ_uppgift
+      properties:
+        operativ_uppgift:
+          $ref: '#/components/schemas/OperativUppgift'
 
     GetUppgifterHandlaggareResponse:
       type: object

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -74,7 +74,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/PostUppgiftHandlaggareResponse'
         '400':
-          description: Bad request (t.ex. felaktigt uppgift_id eller handlaggar_id)
+          description: Bad request (t.ex. felaktigt uppgift_id)
         '403':
           description: Handläggaren tillhör inte teamet
         '404':

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4,7 +4,26 @@ info:
   version: 1.0.0
   description: API för handläggare att hämta ny uppgift och lista sina tilldelade operativa uppgifter.
 
+security:
+  - bearerAuth: []
+
 paths:
+  /uppgifter/handlaggare:
+    post:
+      tags: [OperativtUppgiftslagerController]
+      operationId: postUppgifterHandlaggare
+      summary: Hämta ny uppgift
+      description: Hämta ny uppgift som tilldelas den anropande handläggaren. Handläggarens identitet hämtas från bearer-token.
+      responses:
+        '200':
+          description: Ny uppgift hämtad OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PostUppgifterHandlaggareResponse'
+        '400':
+          description: Bad request
+
   /uppgifter/handlaggare/{id_typ}/{id_varde}:
     parameters:
       - name: id_typ
@@ -21,20 +40,6 @@ paths:
         schema:
           type: string
           example: "123456789"
-    post:
-      tags: [OperativtUppgiftslagerController]
-      operationId: postUppgifterHandlaggare
-      summary: Hämta ny uppgift
-      description: Hämta ny uppgift som tilldelas handläggaren
-      responses:
-        '200':
-          description: Ny uppgift hämtad OK
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/PostUppgifterHandlaggareResponse'
-        '400':
-          description: Bad request (t.ex. felaktigt handlaggar_id)
     get:
       tags: [OperativtUppgiftslagerController]
       operationId: getUppgifterHandlaggare
@@ -52,27 +57,12 @@ paths:
         '403':
           description: Handläggaren tillhör inte teamet
 
-  /uppgifter/team/{id_typ}/{id_varde}:
-    parameters:
-      - name: id_typ
-        in: path
-        required: true
-        description: Typ av identifiering av handläggare
-        schema:
-          type: string
-          example: "kortnummer"
-      - name: id_varde
-        in: path
-        required: true
-        description: Unik identifiering av handläggare
-        schema:
-          type: string
-          example: "123456789"
+  /uppgifter/team:
     get:
       tags: [OperativtUppgiftslagerController]
       operationId: getUppgifterTeam
       summary: Hämta operativa uppgifter tilldelade till handläggarens team
-      description: Returnerar alla operativa uppgifter tilldelade till någon av handläggarens team-medlemmar
+      description: Returnerar alla operativa uppgifter tilldelade till någon av handläggarens team-medlemmar. Handläggarens identitet hämtas från bearer-token.
       responses:
         '200':
           description: Uppgifter hämtade OK
@@ -80,8 +70,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/GetUppgifterHandlaggareResponse'
-        '400':
-          description: Bad request (t.ex. felaktigt id_varde)
         '403':
           description: Handläggaren tillhör inte ett känt team
 
@@ -97,14 +85,8 @@ paths:
     post:
       tags: [OperativtUppgiftslagerController]
       operationId: postUppgiftHandlaggare
-      summary: Tilldela om en uppgift till en annan handläggare
-      description: Tilldelar uppgiften till den angivna handläggaren. Kräver att uppgiftens nuvarande tilldelade handläggare tillhör samma team.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/Idtyp'
+      summary: Tilldela om en uppgift till den anropande handläggaren
+      description: Tilldelar uppgiften till den anropande handläggaren. Handläggarens identitet hämtas från bearer-token. Kräver att uppgiftens nuvarande tilldelade handläggare tillhör samma team.
       responses:
         '200':
           description: Uppgiften omtilldelad OK
@@ -120,6 +102,15 @@ paths:
           description: Uppgiften hittades inte
 
 components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      description: >
+        Bearer-token innehållande handläggarens identitet (id_typ och id_varde,
+        t.ex. "kortnummer" och "123456789"). Används av server-sidan för att
+        fastställa den anropande handläggarens identitet och team-tillhörighet.
+
   schemas:
     PostUppgifterHandlaggareResponse:
       type: object


### PR DESCRIPTION
Extends the OpenAPI spec to support a case worker claiming a task from a colleague in the same team (FKPOC-833).

- GET /uppgifter/handlaggare/{id_typ}/{id_varde} — adds 403 for cross-team access
- GET /uppgifter/team/{id_typ}/{id_varde} — new endpoint returning all tasks assigned to any member of the caller's team
- POST /uppgifter/{uppgift_id}/handlaggare/{id_typ}/{id_varde} — new endpoint for reassigning a task to another case worker in the same team
- PostUppgiftHandlaggareResponse — new response schema (non-nullable operativ_uppgift) distinct from the existing fetch-new-task response